### PR TITLE
Fix Laravel detection in YouTubeClient

### DIFF
--- a/src/Service/YouTubeClient.php
+++ b/src/Service/YouTubeClient.php
@@ -16,8 +16,12 @@ class YouTubeClient
 
     public function __construct()
     {
-        // Check if we're running in Laravel
-        $runningInLaravel = class_exists('\Illuminate\Foundation\Application') && app() instanceof \Illuminate\Foundation\Application;
+        // Check if we're running in Laravel. The `app()` helper may not be
+        // defined when the package is used outside a Laravel environment, so
+        // verify the function exists before invoking it.
+        $runningInLaravel = class_exists('\Illuminate\Foundation\Application')
+            && function_exists('app')
+            && app() instanceof \Illuminate\Foundation\Application;
 
         if ($runningInLaravel) {
             // Get settings from Laravel config


### PR DESCRIPTION
## Summary
- avoid fatal error when the `app` helper does not exist

## Testing
- `composer install`
- `composer test` *(fails: Class "App\Service\YouTubeClient" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405c51b95c832e8f43fcff1aeb3222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções de bugs**
  - Melhorada a detecção do ambiente Laravel para evitar erros ao utilizar o pacote fora do Laravel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->